### PR TITLE
Skip range check when parsing stack trace

### DIFF
--- a/front_end/core/sdk/DebuggerModel.ts
+++ b/front_end/core/sdk/DebuggerModel.ts
@@ -772,16 +772,19 @@ export class DebuggerModel extends SDKModel<EventTypes> {
     return this.createRawLocationByScriptId(script.scriptId, lineNumber, columnNumber, inlineFrameIndex);
   }
 
-  createRawLocationByURL(sourceURL: string, lineNumber: number, columnNumber?: number, inlineFrameIndex?: number):
-      Location|null {
+  createRawLocationByURL(
+      sourceURL: string, lineNumber: number, columnNumber?: number, inlineFrameIndex?: number,
+      skipScriptRangeCheck?: boolean): Location|null {
     for (const script of this.#scriptsBySourceURL.get(sourceURL) || []) {
-      if (script.lineOffset > lineNumber ||
-          (script.lineOffset === lineNumber && columnNumber !== undefined && script.columnOffset > columnNumber)) {
-        continue;
-      }
-      if (script.endLine < lineNumber ||
-          (script.endLine === lineNumber && columnNumber !== undefined && script.endColumn <= columnNumber)) {
-        continue;
+      if (!skipScriptRangeCheck) {
+        if (script.lineOffset > lineNumber ||
+            (script.lineOffset === lineNumber && columnNumber !== undefined && script.columnOffset > columnNumber)) {
+          continue;
+        }
+        if (script.endLine < lineNumber ||
+            (script.endLine === lineNumber && columnNumber !== undefined && script.endColumn <= columnNumber)) {
+          continue;
+        }
       }
       return new Location(this, script.scriptId, lineNumber, columnNumber, inlineFrameIndex);
     }

--- a/front_end/ui/legacy/components/utils/Linkifier.ts
+++ b/front_end/ui/legacy/components/utils/Linkifier.ts
@@ -245,13 +245,15 @@ export class Linkifier extends Common.ObjectWrapper.ObjectWrapper<EventTypes> im
       return fallbackAnchor;
     }
 
+    // TODO(T199120793) Skipping script range check until Hermes implements script range
+    const skipRangeCheck = true;
     // Prefer createRawLocationByScriptId() here, since it will always produce a correct
     // link, since the script ID is unique. Only fall back to createRawLocationByURL()
     // when all we have is an URL, which is not guaranteed to be unique.
     const rawLocation = scriptId ? debuggerModel.createRawLocationByScriptId(
                                        scriptId, lineNumber || 0, columnNumber, linkifyURLOptions.inlineFrameIndex) :
                                    debuggerModel.createRawLocationByURL(
-                                       sourceURL, lineNumber || 0, columnNumber, linkifyURLOptions.inlineFrameIndex);
+                                       sourceURL, lineNumber || 0, columnNumber, linkifyURLOptions.inlineFrameIndex, skipRangeCheck);
     if (!rawLocation) {
       return fallbackAnchor;
     }


### PR DESCRIPTION
# Summary

Hermes is working on implementing proper support for script ranges: [T199120793](https://www.internalfb.com/tasks/?t=199120793). In the meantime, we'll disable the range check so symbolication can be made available.

Long term plans are being discussed [here](https://fburl.com/workplace/obbfr9lt).

# Test plan

Manual E2E test as described in [D60598446](https://www.internalfb.com/diff/D60598446)

# Upstreaming plan

<!-- Pick one: -->

- [ ] This commit should be sent as a patch to the upstream `devtools-frontend` repo. I've reviewed the [contribution guide](https://docs.google.com/document/d/1WNF-KqRSzPLUUfZqQG5AFeU_Ll8TfWYcJasa_XGf7ro/edit#heading=h.9kj7femz1xg5).
- [x] This commit is React Native-specific and cannot be upstreamed.
