### PR TITLE
support symbolication with native frames

### DIFF
--- a/front_end/panels/console/ErrorStackParser.test.ts
+++ b/front_end/panels/console/ErrorStackParser.test.ts
@@ -340,5 +340,25 @@ describe('ErrorStackParser', () => {
       assert.strictEqual(parsedFrames[3].link?.url, urlString`http://example.com/b.js`);
       assert.isTrue(parsedFrames[3].isCallFrame);
     });
+
+    it('combines builtin frames in native frames', () => {
+      const parsedFrames = parseErrorStack(`Error: some error
+        at foo (http://example.com/a.js:6:3)
+        at forEach (native)
+        at JSON.parse (native)
+        at bar (http://example.com/b.js:43:14)`);
+      assert.exists(parsedFrames);
+
+      assert.isUndefined(parsedFrames[0].link);
+      assert.isUndefined(parsedFrames[0].isCallFrame);
+      assert.strictEqual(parsedFrames[1].link?.url, urlString`http://example.com/a.js`);
+      assert.isTrue(parsedFrames[1].isCallFrame);
+      assert.isUndefined(parsedFrames[2].link);
+      assert.isTrue(parsedFrames[2].isCallFrame);
+      assert.strictEqual(
+          parsedFrames[2].line, '        at forEach (native)\n        at JSON.parse (native)');
+      assert.strictEqual(parsedFrames[3].link?.url, urlString`http://example.com/b.js`);
+      assert.isTrue(parsedFrames[3].isCallFrame);
+    });
   });
 });

--- a/front_end/panels/console/ErrorStackParser.ts
+++ b/front_end/panels/console/ErrorStackParser.ts
@@ -75,7 +75,7 @@ export function parseSourcePositionsFromErrorStack(
 
     const linkCandidate = line.substring(left, right);
     const splitResult = Common.ParsedURL.ParsedURL.splitLineAndColumn(linkCandidate);
-    if (splitResult.url === '<anonymous>') {
+    if (splitResult.url === '<anonymous>' || splitResult.url === 'native') {
       if (linkInfos.length && linkInfos[linkInfos.length - 1].isCallFrame && !linkInfos[linkInfos.length - 1].link) {
         // Combine builtin frames.
         linkInfos[linkInfos.length - 1].line += `\n${line}`;


### PR DESCRIPTION
# Make "(native)" RN frames work the same way as "\<anonymous>".

React Native uses these when a call is made to a native function.

Up until now, symbolication was failing when these were encountered. 

Now, symbolication will leave these lines as they are. These lines will be ignore-listed if the function calling the native function was ignore-listed. (Which is how "\<anonymous>" works at the moment)

# Test plan

`npm run test` passes.

Also, for an error stack that includes "(native)":

**Before**: Symbolication failed

**After**: Symbolication succeeded as expected:
<img width="382" alt="Screenshot 2025-06-24 at 13 37 45" src="https://github.com/user-attachments/assets/60bdce3f-ba75-4643-b749-a77cf3493be3" />
<img width="627" alt="Screenshot 2025-06-24 at 13 37 55" src="https://github.com/user-attachments/assets/b1c34719-e749-46cb-a6f4-bd7ca268bef1" />

- [x] This change maintains backwards compatibility with previous Local Storage data (if modifying settings, experiments, or other persisted client state).

# Upstreaming plan

<!-- Pick one: -->

- [ ] This commit should be sent as a patch to the upstream `devtools-frontend` repo. I've reviewed the [contribution guide](https://docs.google.com/document/d/1WNF-KqRSzPLUUfZqQG5AFeU_Ll8TfWYcJasa_XGf7ro/edit#heading=h.9kj7femz1xg5).
- [x] This commit is React Native-specific and cannot be upstreamed.
