### PR TITLE
improve current session id message selectivity

### DIFF
--- a/front_end/panels/rn_welcome/RNWelcome.ts
+++ b/front_end/panels/rn_welcome/RNWelcome.ts
@@ -173,10 +173,11 @@ export class RNWelcomeImpl extends UI.Widget.VBox implements
             </x-link>
           </div>
           ${launchId ? html`
-            <div class="rn-session-id">
+            <div class="rn-session-id-message">
               ${i18nString(UIStrings.sessionIdMessage)}
-              <br/>
-              ${launchId}
+              <div class="rn-session-id">
+                ${launchId}
+              </div>
             </div>
           ` : ''}
           ${this.#reactNativeVersion !== null && this.#reactNativeVersion !== undefined ? html`

--- a/front_end/panels/rn_welcome/rnWelcome.css
+++ b/front_end/panels/rn_welcome/rnWelcome.css
@@ -101,10 +101,12 @@
   border-right: 1px solid var(--sys-color-on-base-divider);
 }
 
-.rn-session-id {
-  display: flex;
-  align-items: center;
+.rn-session-id-message {
+  display: block;
   margin-top: 24px;
+}
+
+.rn-session-id-message > .rn-session-id {
   user-select: all;
 }
 


### PR DESCRIPTION
# Summary
The whole message was selected on click, instead of only the session-id.

# Test plan

<img width="511" height="283" alt="Screenshot 2025-07-14 at 11 23 46" src="https://github.com/user-attachments/assets/09ae19b0-0662-41c8-8ad3-8d55686971c5" />

- [x] This change maintains backwards compatibility with previous Local Storage data (if modifying settings, experiments, or other persisted client state).

# Upstreaming plan

- [ ] This commit should be sent as a patch to the upstream `devtools-frontend` repo. I've reviewed the [contribution guide](https://docs.google.com/document/d/1WNF-KqRSzPLUUfZqQG5AFeU_Ll8TfWYcJasa_XGf7ro/edit#heading=h.9kj7femz1xg5).
- [x] This commit is React Native-specific and cannot be upstreamed.
