### PR TITLE
allow parsing stack traces that end with "skipping x frames"

### DIFF
--- a/front_end/panels/console/ErrorStackParser.ts
+++ b/front_end/panels/console/ErrorStackParser.ts
@@ -21,32 +21,43 @@ export interface ParsedErrorFrame {
   };
 }
 
-export type SpecialHermesStackTraceFrameTypes = 'native' | 'address at' | 'empty url';
+export type SpecialHermesStackTraceFrameTypes =
+  // e.g "(native)"- Functions implemented on the native side.
+  // TODO: Might be enhanced to include the native (C++/Java/etc) loc
+  // for the frame so that a debugger could stitch together a
+  // hybrid cross-language call stack
+  'native' |
+  // e.g "(:3:4)"- Frames with empty url
+  // TODO: Seems to be happening due to a bug that needs to be investigated
+  // and produce an actual script URL instead
+  'empty url' |
+  // e.g "(address at InternalBytecode.js:5:6)"- Frames pointing to bytecode locations
+  // TODO: Could be symbolicated and link to source files with the help of
+  // a bytecode source maps once they are available.
+  'address at' |
+  // e.g " ... skipping 7 frames" - Frames collapsed in the middle of a stack trace
+  // for very long stack traces
+  'skipping x frames' ;
 
-function getSpecialHermesStackTraceFrameType({
-    url,
-}: {
-  url: Platform.DevToolsPath.UrlString,
-}): SpecialHermesStackTraceFrameTypes | null {
-  // functions implemented in c++.
-  // TODO: these might be enhanced to include the C++ loc for the frame
-  // so that a debugger could stitch together a hybrid cross-language call stack
+function getSpecialHermesFrameBasedOnURL(url: string): SpecialHermesStackTraceFrameTypes | null {
   if (url === 'native') {
     return 'native';
   }
 
-  // frames with empty url
-  // TODO: these seem to be happening due to a bug that needs to be investigated
-  // and produce an actual script URL instead
   if (url === '') {
     return 'empty url';
   }
 
-  // frames pointing to a bytecode locations
-  // TODO: these could be symbolicated and link to source files with the help of
-  // a bytecode source maps once they are available.
   if (url.startsWith?.('address at ')) {
     return 'address at';
+  }
+
+  return null;
+}
+
+function getSpecialHermesFrameBasedOnLine(line: string): SpecialHermesStackTraceFrameTypes | null {
+  if (/^\s*... skipping \d+ frames$/.exec(line)) {
+    return 'skipping x frames';
   }
 
   return null;
@@ -77,6 +88,18 @@ export function parseSourcePositionsFromErrorStack(
     const match = /^\s*at\s(async\s)?/.exec(line);
     if (!match) {
       if (linkInfos.length && linkInfos[linkInfos.length - 1].isCallFrame) {
+        const specialHermesFrameType = getSpecialHermesFrameBasedOnLine(line);
+        if (specialHermesFrameType) {
+          specialHermesFramesParsed.add(specialHermesFrameType);
+          if (!linkInfos[linkInfos.length - 1].link) {
+            // Combine builtin frames.
+            linkInfos[linkInfos.length - 1].line += `\n${line}`;
+          } else {
+            linkInfos.push({line, isCallFrame: false});
+          }
+          continue;
+        }
+
         Host.rnPerfMetrics.stackTraceSymbolicationFailed(stack, line, '"at (url)" not found');
         return null;
       }
@@ -112,16 +135,17 @@ export function parseSourcePositionsFromErrorStack(
 
     const linkCandidate = line.substring(left, right);
     const splitResult = Common.ParsedURL.ParsedURL.splitLineAndColumn(linkCandidate);
-    const specialHermesFrameType = getSpecialHermesStackTraceFrameType(splitResult);
+    const specialHermesFrameType = getSpecialHermesFrameBasedOnURL(splitResult.url);
+    if (specialHermesFrameType) {
+      specialHermesFramesParsed.add(specialHermesFrameType);
+    }
+
     if (splitResult.url === '<anonymous>' || specialHermesFrameType !== null) {
       if (linkInfos.length && linkInfos[linkInfos.length - 1].isCallFrame && !linkInfos[linkInfos.length - 1].link) {
         // Combine builtin frames.
         linkInfos[linkInfos.length - 1].line += `\n${line}`;
       } else {
         linkInfos.push({line, isCallFrame});
-      }
-      if (specialHermesFrameType !== null) {
-        specialHermesFramesParsed.add(specialHermesFrameType);
       }
       continue;
     }


### PR DESCRIPTION
# Summary
Following https://github.com/facebook/react-native-devtools-frontend/pull/188, allow frames of the format ` ... skipping x frames` (where x is a number) coming from Hermes for huge stack traces and track it as a special frame.

# Test plan

For a 1000 stack created with recursion:
<img width="734" height="449" alt="Screenshot 2025-07-21 at 16 42 01" src="https://github.com/user-attachments/assets/e2cefa26-c528-47fe-88f1-183d7a4c6799" />

Before:
<img width="926" height="354" alt="Screenshot 2025-07-21 at 16 41 39" src="https://github.com/user-attachments/assets/47d21283-5355-42a8-85d7-9bce7f2a0505" />

After:
<img width="373" height="336" alt="Screenshot 2025-07-21 at 17 07 34" src="https://github.com/user-attachments/assets/98b821b0-0891-47ce-94be-bbd08a0b4b06" />

- [x] This change maintains backwards compatibility with previous Local Storage data (if modifying settings, experiments, or other persisted client state).

# Upstreaming plan

<!-- Pick one: -->

- [ ] This commit should be sent as a patch to the upstream `devtools-frontend` repo following the [contribution guide for Meta employees](https://fburl.com/wiki/43s6yft1) OR [contribution guide](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/contributing/README.md).
- [x] This commit is React Native-specific and cannot be upstreamed.
