### PR TITLE
[DevTools][Protocol Manager] Fixed Protocol Monitor displaying CDP events as "(pending)"

### DIFF
--- a/front_end/panels/protocol_monitor/ProtocolMonitor.ts
+++ b/front_end/panels/protocol_monitor/ProtocolMonitor.ts
@@ -277,7 +277,7 @@ export const DEFAULT_VIEW: View = (input, output, target) => {
                         <td>
                           ${message.result    ? html`<code>${JSON.stringify(message.result)}</code>` :
                                 message.error ? html`<code>${JSON.stringify(message.error)}</code>` :
-                                                '(pending)'}
+                              'id' in message ? '(pending)' : ''}
                         </td>
                         <td data-value=${message.elapsedTime || 0}>
                           ${!('id' in message)  ? '' :


### PR DESCRIPTION
# Summary

CDP events pending doesn't make sense, since events can't be updated after they arrive (since they don't have an id anyway): https://github.com/ChromeDevTools/devtools-frontend/blob/3201a3630665afd30e0a879f4ebeae6fcc4f3806/front_end/panels/protocol_monitor/ProtocolMonitor.ts#L562-L587

Also, events are allowed to have no params based on:
* JSON-RPC 2.0 Specification: https://www.jsonrpc.org/specification#:~:text=This%20member%20MAY%20be%20omitted
* and CDP Wire Format: https://chromium.googlesource.com/chromium/src/+/master/third_party/blink/public/devtools_protocol/#:~:text=CDP%20is%20designed%20with%20JSON%2DRPC%202.0%20as%20the%20primary%20wire%20format

The two events that caught my eye are:
* Debugger.resumed https://chromedevtools.github.io/devtools-protocol/tot/Debugger/#event-resumed
* and Runtime.executionContextsCleared https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#event-executionContextsCleared

Both are expected to be sent without params, however Chrome does send an empty object params for them.

I work on the DevTools branch for React Native-
https://github.com/facebook/react-native-devtools-frontend

We've omitted "params" for these events as per the CDP docs, resulting in "(pending)" displayed in the Protocol Monitor. We thought we made a mistake at first, but it turns out it's just the Protocol Monitor's UI.

# Test plan

<img width="1581" height="728" alt="Screenshot 2025-08-20 at 11 37 19" src="https://github.com/user-attachments/assets/8f3c3bcc-c296-4590-895b-4f7a1b518b03" />

- [x] This change maintains backwards compatibility with previous Local Storage data (if modifying settings, experiments, or other persisted client state).

# Upstreaming plan

<!-- Pick one: -->

- [x] This commit was upstreamed to google at https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/6862800 and this is a pick back to us.
- [ ] This commit should be sent as a patch to the upstream `devtools-frontend` repo following the [contribution guide for Meta employees](https://fburl.com/wiki/43s6yft1) OR [contribution guide](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/contributing/README.md).
- [ ] This commit is React Native-specific and cannot be upstreamed.
