### PR TITLE
Revert "Add landingView query param enabling view focus on launch (#1…

### DIFF
--- a/front_end/entrypoints/main/MainImpl.ts
+++ b/front_end/entrypoints/main/MainImpl.ts
@@ -571,12 +571,6 @@ export class MainImpl {
       Timeline.TimelinePanel.LoadTimelineHandler.instance().handleQueryParam(value);
     }
 
-    // Allow &landingView query param to override the default landing view.
-    const landingView = Root.Runtime.Runtime.queryParam('landingView');
-    if (landingView !== null) {
-      await UI.ViewManager.ViewManager.instance().showView(landingView);
-    }
-
     // Initialize ARIAUtils.alert Element
     UI.ARIAUtils.getOrCreateAlertElements();
     UI.DockController.DockController.instance().announceDockLocation();


### PR DESCRIPTION
This reverts commit 7dcbddd636137a9604d69a99cc69221216cd4be6.

# Summary

I've discovered today that CDT has a native support for the `panel` query param, so we don't need a custom one. 

https://github.com/facebook/react-native-devtools-frontend/blob/7411149fb580997b03862748742ce3b7a045c9f0/front_end/ui/legacy/InspectorView.ts#L206-L209

# Test plan

<!-- Explain how you've tested your change here -->

- [x] This change maintains backwards compatibility with previous Local Storage data (if modifying settings, experiments, or other persisted client state).

# Upstreaming plan

<!-- Pick one: -->

- [ ] This commit should be sent as a patch to the upstream `devtools-frontend` repo following the [contribution guide for Meta employees](https://fburl.com/wiki/43s6yft1) OR [contribution guide](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/contributing/README.md).
- [x] This commit is React Native-specific and cannot be upstreamed.
