### PR TITLE
fix: avoid race conditions when fetching background trace

### DIFF
--- a/front_end/entrypoints/main/MainImpl.ts
+++ b/front_end/entrypoints/main/MainImpl.ts
@@ -569,6 +569,12 @@ export class MainImpl {
       // would request and evaluate the Timeline panel dep tree, slowing down the UI's load.
       const Timeline = await import('../../panels/timeline/timeline.js');
       Timeline.TimelinePanel.LoadTimelineHandler.instance().handleQueryParam(value);
+    } else {
+      const panel = Root.Runtime.Runtime.queryParam('panel');
+      if (panel === 'timeline') {
+        // [RN] If panel is specified, we need Timeline to be ready and be subscribed to the events that will be emitted.
+        await import('../../panels/timeline/timeline.js');
+      }
     }
 
     // Initialize ARIAUtils.alert Element

--- a/front_end/panels/timeline/TimelineController.ts
+++ b/front_end/panels/timeline/TimelineController.ts
@@ -203,12 +203,11 @@ export class TimelineController implements Trace.TracingManager.TracingManagerCl
   }
 
   async rnPrepareForTraceCapturedInBackground(): Promise<void> {
-    await LiveMetrics.LiveMetrics.instance().disable();
-
     if (this.tracingManager) {
       this.tracingManager.rnPrepareForTraceCapturedInBackground(this);
     }
 
+    await LiveMetrics.LiveMetrics.instance().disable();
     this.client.loadingStarted();
     await this.allSourcesFinished();
     await LiveMetrics.LiveMetrics.instance().enable();


### PR DESCRIPTION
# Summary

This includes 2 changes:
1. If the `panel` query parameter is specified, which we are using to pre-open Timeline panel, we are going to static import it. If we will load it dynamically, there could be scenarios when it won't subscribe to `ReactNativeApplication` domain in time and will miss the required event to prepare for a incoming trace.
2. Inside the TimelineController, update the TracingClient state synchronously first. This happens on `start()` event. if we don't do it, there are chances that `tracingComplete()` event could be handled first and it won't capture the trace.

# Test plan

<!-- Explain how you've tested your change here -->

- [x] This change maintains backwards compatibility with previous Local Storage data (if modifying settings, experiments, or other persisted client state).

# Upstreaming plan

<!-- Pick one: -->

- [ ] This commit should be sent as a patch to the upstream `devtools-frontend` repo following the [contribution guide for Meta employees](https://fburl.com/wiki/43s6yft1) OR [contribution guide](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/contributing/README.md).
- [x] This commit is React Native-specific and cannot be upstreamed.
