### PR TITLE
Disable Perf Insights subpanel, collapse sidebar by default

### DIFF
--- a/front_end/panels/timeline/TimelinePanel.ts
+++ b/front_end/panels/timeline/TimelinePanel.ts
@@ -772,7 +772,7 @@ export class TimelinePanel extends UI.Panel.Panel implements Client, TimelineMod
   #setActiveInsight(insight: TimelineComponents.Sidebar.ActiveInsight|null): void {
     // When an insight is selected, ensure that the 3P checkbox is disabled
     // to avoid dimming interference.
-    if (insight) {
+    if (insight && !Root.Runtime.experiments.isEnabled(Root.Runtime.ExperimentName.REACT_NATIVE_SPECIFIC_UI)) {
       this.#splitWidget.showBoth();
     }
     this.#sideBar.setActiveInsight(insight);
@@ -2183,6 +2183,10 @@ export class TimelinePanel extends UI.Panel.Panel implements Client, TimelineMod
   #showSidebarIfRequired(): void {
     if (Root.Runtime.Runtime.queryParam('disable-auto-performance-sidebar-reveal') !== null) {
       // Used in interaction tests & screenshot tests.
+      return;
+    }
+    // [RN] Keep sidebar collapsed by default
+    if (Root.Runtime.experiments.isEnabled(Root.Runtime.ExperimentName.REACT_NATIVE_SPECIFIC_UI)) {
       return;
     }
     const needToRestore = this.#restoreSidebarVisibilityOnTraceLoad;

--- a/front_end/panels/timeline/components/Sidebar.ts
+++ b/front_end/panels/timeline/components/Sidebar.ts
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import * as Common from '../../../core/common/common.js';
+import * as Root from '../../../core/root/root.js';
 import type * as Trace from '../../../models/trace/trace.js';
 import * as UI from '../../../ui/legacy/legacy.js';
 
@@ -68,16 +69,21 @@ export class SidebarWidget extends UI.Widget.VBox {
   constructor() {
     super();
     this.setMinimumSize(MIN_SIDEBAR_WIDTH_PX, 0);
-    this.#tabbedPane.appendTab(
-        SidebarTabs.INSIGHTS, 'Insights', this.#insightsView, undefined, undefined, false, false, 0,
-        'timeline.insights-tab');
+
+    // [RN] Disable Insights tab
+    const showInsightsTab = !Root.Runtime.experiments.isEnabled(Root.Runtime.ExperimentName.REACT_NATIVE_SPECIFIC_UI);
+
+    if (showInsightsTab) {
+      this.#tabbedPane.appendTab(
+          SidebarTabs.INSIGHTS, 'Insights', this.#insightsView, undefined, undefined, false, false, 0,
+          'timeline.insights-tab');
+    }
+
     this.#tabbedPane.appendTab(
         SidebarTabs.ANNOTATIONS, 'Annotations', this.#annotationsView, undefined, undefined, false, false, 1,
         'timeline.annotations-tab');
 
-    // Default the selected tab to Insights. In wasShown() we will change this
-    // if this is a trace that has no insights.
-    this.#tabbedPane.selectTab(SidebarTabs.INSIGHTS);
+    this.#tabbedPane.selectTab(showInsightsTab ? SidebarTabs.INSIGHTS : SidebarTabs.ANNOTATIONS);
   }
 
   override wasShown(): void {


### PR DESCRIPTION
# Summary

UI tweaks to the Performance panel for inactive features in React Native.

# Test plan

<img width="582" height="355" alt="image" src="https://github.com/user-attachments/assets/47554f2f-2b7c-4979-91a6-d35f7c3c26f4" />

✅ Sidebar collapsed by default when trace open

<img width="552" height="414" alt="image" src="https://github.com/user-attachments/assets/02b40940-0a04-43f1-b496-b0c36bae607c" />

✅ "Annotations" is the only panel available

- [ ] This change maintains backwards compatibility with previous Local Storage data (if modifying settings, experiments, or other persisted client state).

# Upstreaming plan

<!-- Pick one: -->

- [ ] This commit should be sent as a patch to the upstream `devtools-frontend` repo following the [contribution guide for Meta employees](https://fburl.com/wiki/43s6yft1) OR [contribution guide](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/contributing/README.md).
- [x] This commit is React Native-specific and cannot be upstreamed.
