### PR TITLE
Formalise ENABLE_TIMELINE_FRAMES experiment

### DIFF
--- a/front_end/core/rn_experiments/experimentsImpl.ts
+++ b/front_end/core/rn_experiments/experimentsImpl.ts
@@ -189,5 +189,4 @@ Instance.register({
   name: RNExperimentName.ENABLE_TIMELINE_FRAMES,
   title: 'Enable performance frames track',
   unstable: true,
-  enabledByDefault: () => globalThis.enableTimelineFrames ?? false,
 });

--- a/front_end/entrypoints/rn_fusebox/FuseboxFeatureObserver.ts
+++ b/front_end/entrypoints/rn_fusebox/FuseboxFeatureObserver.ts
@@ -30,6 +30,12 @@ const UIStrings = {
    */
   multiHostFeatureUnavailableTitle: 'Feature is unavailable',
   /**
+   * @description Message for the "settings changed" banner shown when a reload
+   * is required for frame timings in the Performance panel.
+   */
+  reloadRequiredForTimelineFramesMessage:
+      'Frame timings and screenshots are now available in the Performance panel. Please reload to enable.',
+  /**
    * @description Detail message shown when a feature is disabled due to multiple React Native hosts.
    */
   multiHostFeatureDisabledDetail: 'This feature is disabled as the app or framework has registered multiple React Native hosts, which is not currently supported.',
@@ -75,7 +81,7 @@ export class FuseboxFeatureObserver implements
   #handleMetadataUpdated(
       event: Common.EventTarget.EventTargetEvent<Protocol.ReactNativeApplication.MetadataUpdatedEvent>): void {
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const {unstable_isProfilingBuild, unstable_networkInspectionEnabled} = event.data;
+    const {unstable_isProfilingBuild, unstable_networkInspectionEnabled, unstable_frameRecordingEnabled} = event.data;
 
     if (unstable_isProfilingBuild) {
       FuseboxWindowTitleManager.instance().setSuffix('[PROFILING]');
@@ -86,6 +92,10 @@ export class FuseboxFeatureObserver implements
     // TODO(huntie): Remove after fbsource rollout is complete
     if (!unstable_networkInspectionEnabled && !Root.Runtime.conditions.reactNativeExpoNetworkPanel()) {
       this.#hideNetworkPanel();
+    }
+
+    if (unstable_frameRecordingEnabled) {
+      void this.#ensureTimelineFramesEnabled();
     }
   }
 
@@ -130,6 +140,14 @@ export class FuseboxFeatureObserver implements
     void viewManager.resolveLocation(UI.ViewManager.ViewLocationValues.PANEL).then(location => {
       location?.removeView(viewManager.view('network'));
     });
+  }
+
+  async #ensureTimelineFramesEnabled(): Promise<void> {
+    if (!Root.Runtime.experiments.isEnabled(Root.Runtime.RNExperimentName.ENABLE_TIMELINE_FRAMES)) {
+      Root.Runtime.experiments.setEnabled(Root.Runtime.RNExperimentName.ENABLE_TIMELINE_FRAMES, true);
+      UI.InspectorView?.InspectorView?.instance()?.displayReloadRequiredWarning(
+          i18nString(UIStrings.reloadRequiredForTimelineFramesMessage));
+    }
   }
 
   #disableSingleHostOnlyFeatures(): void {

--- a/front_end/generated/protocol.ts
+++ b/front_end/generated/protocol.ts
@@ -61,6 +61,11 @@ export namespace ReactNativeApplication {
      * Enables the Network Panel.
      */
     unstable_networkInspectionEnabled?: boolean;
+    /**
+     * Whether Frame Timings and screenshots are supported in performance
+     * traces.
+     */
+    unstable_frameRecordingEnabled?: boolean;
   }
 
   /**

--- a/front_end/panels/timeline/TimelinePanel.ts
+++ b/front_end/panels/timeline/TimelinePanel.ts
@@ -713,14 +713,6 @@ export class TimelinePanel extends UI.Panel.Panel implements Client, TimelineMod
         {
           modelAdded: (model: SDK.ReactNativeApplicationModel.ReactNativeApplicationModel) => {
             model.addEventListener(
-              SDK.ReactNativeApplicationModel.Events.METADATA_UPDATED,
-              (event: Common.EventTarget.EventTargetEvent<Protocol.ReactNativeApplication.MetadataUpdatedEvent>) => {
-                if (event.data.platform === 'android') {
-                  this.showScreenshotsToolbarCheckbox?.setVisible(true);
-                }
-              }
-            );
-            model.addEventListener(
               SDK.ReactNativeApplicationModel.Events.TRACE_REQUESTED, () => this.rnPrepareForTraceCapturedInBackground());
           },
           modelRemoved: (_model: SDK.ReactNativeApplicationModel.ReactNativeApplicationModel) => {},
@@ -1200,17 +1192,6 @@ export class TimelinePanel extends UI.Panel.Panel implements Client, TimelineMod
     if (!isNode && (Root.Runtime.experiments.isEnabled(Root.Runtime.RNExperimentName.ENABLE_TIMELINE_FRAMES) || !isReactNative)) {
       this.showScreenshotsToolbarCheckbox =
           this.createSettingCheckbox(this.showScreenshotsSetting, i18nString(UIStrings.captureScreenshots));
-
-      let showScreenshotsToggle = false;
-
-      const reactNativeApplicationModel = SDK.TargetManager.TargetManager.instance().primaryPageTarget()?.model(SDK.ReactNativeApplicationModel.ReactNativeApplicationModel);
-      if (reactNativeApplicationModel !== null && reactNativeApplicationModel !== undefined) {
-        showScreenshotsToggle = reactNativeApplicationModel.metadataCached?.platform === 'android';
-      }
-
-      // Only show this toggle if we are on android, to address a possible race condition with the platform metadata,
-      // this is also checked again on SDK.ReactNativeApplicationModel.Events.METADATA_UPDATED
-      this.showScreenshotsToolbarCheckbox.setVisible(showScreenshotsToggle);
       this.panelToolbar.appendToolbarItem(this.showScreenshotsToolbarCheckbox);
     }
 

--- a/third_party/blink/public/devtools_protocol/browser_protocol.json
+++ b/third_party/blink/public/devtools_protocol/browser_protocol.json
@@ -69,6 +69,12 @@
                             "description": "Enables the Network Panel.",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "unstable_frameRecordingEnabled",
+                            "description": "Whether Frame Timings and screenshots are supported in performance traces.",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },

--- a/third_party/blink/public/devtools_protocol/react_native_domains.pdl
+++ b/third_party/blink/public/devtools_protocol/react_native_domains.pdl
@@ -30,6 +30,8 @@ experimental domain ReactNativeApplication
       optional boolean unstable_isProfilingBuild
       # Enables the Network Panel.
       optional boolean unstable_networkInspectionEnabled
+      # Whether Frame Timings and screenshots are supported in performance traces.
+      optional boolean unstable_frameRecordingEnabled
 
   # Emitted when assertions about the debugger backend have changed.
   event systemStateChanged


### PR DESCRIPTION
# Summary

> [!Note]
> Paired with https://github.com/facebook/react-native/pull/55941, should be synced into `react-native` afterwards.

Formalise the existing `ENABLE_TIMELINE_FRAMES` experiment, by removing the scattered `globalThis.enableTimelineFrames` and `platform === 'android'` checks, and ensuring the UI is correctly synced in both states.

This allows us to control enabling this feature from the backend (`ReactNativeApplication.metadataEnabled → { unstable_frameRecordingEnabled }`), as we experiment and add support per platform.

Also cleans up additional code forks in `TimelinePanel.js`.

**Rollout plan (future)**

- **Development** `unstable_frameRecordingEnabled` (this change): Backend-driven enabling of this experiment, when the corresponding React Native feature flag is enabled.
- **Canary**: At some point in the future when the CDP backend is semi-stable on both platforms, enable by default in RN, but preserve the `ENABLE_TIMELINE_FRAMES` experiment here — enabling per-user opt-in.
- **Stable**: Remove flag from frontend for general rollout.

# Test plan

**Experiment disabled**

<img width="1083" height="129" alt="image" src="https://github.com/user-attachments/assets/f44ffe7e-d018-4968-99d0-38fe4620eb6f" />

✅ No Screenshots toggle available

**Experiment enabled**

When `unstable_frameRecordingEnabled` is sent by the backend:

<img width="1245" height="183" alt="image" src="https://github.com/user-attachments/assets/364664ef-0a16-4344-8176-fc698cf7ee6f" />

✅ Initial user notification for backend-touched experiment

<img width="1131" height="122" alt="image" src="https://github.com/user-attachments/assets/115a0882-8c5b-4c1f-841f-7d4ff575fc82" />

✅ Upon refresh, Screenshots toggle is enabled in Performance panel

- [x] This change maintains backwards compatibility with previous Local Storage data (if modifying settings, experiments, or other persisted client state).

# Upstreaming plan

<!-- Pick one: -->

- [ ] This commit should be sent as a patch to the upstream `devtools-frontend` repo following the [contribution guide for Meta employees](https://fburl.com/wiki/43s6yft1) OR [contribution guide](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/contributing/README.md).
- [x] This commit is React Native-specific and cannot be upstreamed.
