### PR TITLE
Enable "Capture screenshot" command for React Native targets

### DIFF
--- a/front_end/panels/emulation/DeviceModeWrapper.ts
+++ b/front_end/panels/emulation/DeviceModeWrapper.ts
@@ -110,7 +110,11 @@ export class ActionDelegate implements UI.ActionRegistration.ActionDelegate {
   handleAction(context: UI.Context.Context, actionId: string): boolean {
     switch (actionId) {
       case 'emulation.capture-screenshot':
-        return DeviceModeWrapper.instance().captureScreenshot();
+        if (deviceModeWrapperInstance) {
+          return DeviceModeWrapper.instance().captureScreenshot();
+        }
+        void captureScreenshotDirect();
+        return true;
 
       case 'emulation.capture-node-screenshot': {
         const node = context.flavor(SDK.DOMModel.DOMNode);
@@ -163,4 +167,22 @@ export class ActionDelegate implements UI.ActionRegistration.ActionDelegate {
     }
     return false;
   }
+}
+
+async function captureScreenshotDirect(): Promise<void> {
+  const target = SDK.TargetManager.TargetManager.instance().primaryPageTarget();
+  const screenCaptureModel = target?.model(SDK.ScreenCaptureModel.ScreenCaptureModel);
+  if (!screenCaptureModel) {
+    return;
+  }
+  const screenshot = await screenCaptureModel.captureScreenshot(
+      'png' as Protocol.Page.CaptureScreenshotRequestFormat, 100,
+      SDK.ScreenCaptureModel.ScreenshotMode.FROM_VIEWPORT);
+  if (!screenshot) {
+    return;
+  }
+  const link = document.createElement('a');
+  link.download = 'screenshot.png';
+  link.href = 'data:image/png;base64,' + screenshot;
+  link.click();
 }

--- a/front_end/panels/emulation/emulation-meta.ts
+++ b/front_end/panels/emulation/emulation-meta.ts
@@ -103,7 +103,8 @@ UI.ActionRegistration.registerActionExtension({
     const Emulation = await loadEmulationModule();
     return new Emulation.DeviceModeWrapper.ActionDelegate();
   },
-  condition: Root.Runtime.conditions.canDock,
+  // [RN] Available without docking for React Native targets.
+  // condition: Root.Runtime.conditions.canDock,
   title: i18nLazyString(UIStrings.captureScreenshot),
 });
 

--- a/front_end/panels/emulation/emulation-meta.ts
+++ b/front_end/panels/emulation/emulation-meta.ts
@@ -104,7 +104,8 @@ UI.ActionRegistration.registerActionExtension({
     const Emulation = await loadEmulationModule();
     return new Emulation.DeviceModeWrapper.ActionDelegate();
   },
-  condition: Root.Runtime.conditions.canDock,
+  // [RN] Available without docking for React Native targets.
+  // condition: Root.Runtime.conditions.canDock,
   title: i18nLazyString(UIStrings.captureScreenshot),
 });
 


### PR DESCRIPTION
# Summary

Enables the "Capture screenshot" command in the DevTools Command Palette, following https://github.com/facebook/react-native/pull/56307 (support for ad-hoc individual app screenshots).

**Note**: This has not been linked to backend gating of `Page.captureScreenshot` — motivation being, this is hard enough to discover already and shouldn't negatively affect anyone (see also https://github.com/facebook/react-native-devtools-frontend/pull/251).

# Test plan

- Open command palette (cmd + shift + p)
- Select "Capture screenshot"

<img width="647" height="157" alt="image" src="https://github.com/user-attachments/assets/933ef075-11ef-4add-a28e-80963660fa93" />

✅ Command available

<img width="1476" height="217" alt="image" src="https://github.com/user-attachments/assets/8690ae08-b556-423e-b6b4-ebc2020c5fab" />

<img width="1237" height="601" alt="image" src="https://github.com/user-attachments/assets/17360983-352e-47a4-b743-6a7dbb178c7a" />

✅ Saves to file

# Upstreaming plan

<!-- Pick one: -->

- [ ] This commit should be sent as a patch to the upstream `devtools-frontend` repo following the [contribution guide for Meta employees](https://fburl.com/wiki/43s6yft1) OR [contribution guide](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/contributing/README.md).
- [x] This commit is React Native-specific and cannot be upstreamed.
